### PR TITLE
Add initial C++ 1brc implementation

### DIFF
--- a/src/1brc.cpp
+++ b/src/1brc.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#include <fstream>
+#include <unordered_map>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <limits>
+#include <iomanip>
+
+struct Stats {
+    long count = 0;
+    double sum = 0.0;
+    double min = std::numeric_limits<double>::max();
+    double max = -std::numeric_limits<double>::max();
+};
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: 1brc <input-file>" << std::endl;
+        return 1;
+    }
+    std::ifstream in(argv[1]);
+    if (!in) {
+        std::cerr << "failed to open input file" << std::endl;
+        return 1;
+    }
+    std::unordered_map<std::string, Stats> data;
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.empty()) continue;
+        std::size_t pos = line.find(';');
+        if (pos == std::string::npos) continue;
+        std::string name = line.substr(0, pos);
+        double temp = std::stod(line.substr(pos + 1));
+        Stats &s = data[name];
+        s.count++;
+        s.sum += temp;
+        if (temp < s.min) s.min = temp;
+        if (temp > s.max) s.max = temp;
+    }
+    std::vector<std::string> names;
+    names.reserve(data.size());
+    for (auto const& kv : data) names.push_back(kv.first);
+    std::sort(names.begin(), names.end());
+
+    std::cout.setf(std::ios::fixed);
+    std::cout << std::setprecision(1);
+
+    bool first = true;
+    for (auto const& name : names) {
+        const Stats& s = data[name];
+        if (!first) std::cout << ", ";
+        first = false;
+        std::cout << name << "=" << s.min << "/" << (s.sum / s.count) << "/" << s.max;
+    }
+    std::cout << std::endl;
+    return 0;
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,3 +3,4 @@ all:
 	g++ magnet_uri.cpp -o uri -ltorrent-rasterbar -lboost_filesystem -lboost_system -std=c++0x
 	g++ info.cpp -o info -ltorrent-rasterbar -lboost_filesystem -lboost_system -std=c++0x
 	g++ client_.cpp -o client_ -ltorrent-rasterbar -lboost_filesystem -lboost_system -std=c++0x
+	g++ 1brc.cpp -o 1brc -O2 -std=c++17


### PR DESCRIPTION
## Summary
- implement a C++ solution for the 1BRC challenge
- compile the new tool via Makefile

## Testing
- `make -C src 1brc`
- `./1brc test.csv`

------
https://chatgpt.com/codex/tasks/task_e_68417cc006f883239b39089c1da852c9