### PR TITLE
Optimize 1BRC with mmap

### DIFF
--- a/src/1brc.cpp
+++ b/src/1brc.cpp
@@ -1,11 +1,15 @@
 #include <iostream>
-#include <fstream>
 #include <unordered_map>
 #include <vector>
-#include <string>
+#include <string_view>
 #include <algorithm>
 #include <limits>
 #include <iomanip>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstdlib>
 
 struct Stats {
     long count = 0;
@@ -19,28 +23,52 @@ int main(int argc, char* argv[]) {
         std::cerr << "usage: 1brc <input-file>" << std::endl;
         return 1;
     }
-    std::ifstream in(argv[1]);
-    if (!in) {
-        std::cerr << "failed to open input file" << std::endl;
+
+    int fd = open(argv[1], O_RDONLY);
+    if (fd < 0) {
+        perror("open");
         return 1;
     }
-    std::unordered_map<std::string, Stats> data;
-    std::string line;
-    while (std::getline(in, line)) {
-        if (line.empty()) continue;
-        std::size_t pos = line.find(';');
-        if (pos == std::string::npos) continue;
-        std::string name = line.substr(0, pos);
-        double temp = std::stod(line.substr(pos + 1));
-        Stats &s = data[name];
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        perror("fstat");
+        close(fd);
+        return 1;
+    }
+    size_t size = st.st_size;
+    char* data = static_cast<char*>(mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0));
+    if (data == MAP_FAILED) {
+        perror("mmap");
+        close(fd);
+        return 1;
+    }
+    close(fd);
+
+    std::unordered_map<std::string_view, Stats> stats;
+    const char* ptr = data;
+    const char* end = data + size;
+
+    while (ptr < end) {
+        const char* name_start = ptr;
+        while (ptr < end && *ptr != ';') ++ptr;
+        if (ptr >= end) break;
+        std::string_view name(name_start, ptr - name_start);
+        ++ptr; // skip ';'
+        char* num_end;
+        double temp = strtod(ptr, &num_end);
+        ptr = num_end;
+        while (ptr < end && (*ptr == '\n' || *ptr == '\r')) ++ptr;
+
+        Stats& s = stats[name];
         s.count++;
         s.sum += temp;
         if (temp < s.min) s.min = temp;
         if (temp > s.max) s.max = temp;
     }
-    std::vector<std::string> names;
-    names.reserve(data.size());
-    for (auto const& kv : data) names.push_back(kv.first);
+
+    std::vector<std::string_view> names;
+    names.reserve(stats.size());
+    for (auto const& kv : stats) names.push_back(kv.first);
     std::sort(names.begin(), names.end());
 
     std::cout.setf(std::ios::fixed);
@@ -48,11 +76,12 @@ int main(int argc, char* argv[]) {
 
     bool first = true;
     for (auto const& name : names) {
-        const Stats& s = data[name];
+        const Stats& s = stats[name];
         if (!first) std::cout << ", ";
         first = false;
         std::cout << name << "=" << s.min << "/" << (s.sum / s.count) << "/" << s.max;
     }
     std::cout << std::endl;
+    munmap(data, size);
     return 0;
 }


### PR DESCRIPTION
## Summary
- refactor 1brc.cpp to use mmap for input
- avoid copying strings by using `std::string_view`
- ensure mapped memory is unmapped on exit

## Testing
- `g++ 1brc.cpp -o /tmp/1brc_test -O2 -std=c++17 && /tmp/1brc_test /tmp/data.txt`

------
https://chatgpt.com/codex/tasks/task_e_6841804c2790832380a08a9c60e05592